### PR TITLE
fix: Starlette 1.0 compatibility — replace add_event_handler

### DIFF
--- a/ytnoti/__init__.py
+++ b/ytnoti/__init__.py
@@ -404,8 +404,8 @@ class AsyncYouTubeNotifier:
         :param app: The FastAPI app instance to add the event handlers for.
         :param callback_url: The callback URL for the notifier.
         """
-        app.add_event_handler(
-            "startup",
+        # Starlette 1.0 removed add_event_handler; use router.on_startup instead
+        app.router.on_startup.append(
             lambda: asyncio.create_task(self._on_startup(callback_url=callback_url)),
         )
 


### PR DESCRIPTION
## Summary

Fixes #5 — `AttributeError: 'FastAPI' object has no attribute 'add_event_handler'` with Starlette 1.0+.

## Changes

Replaced `app.add_event_handler("startup", handler)` with `app.router.on_startup.append(handler)` at lines 411-418 of `ytnoti/__init__.py`.

`router.on_startup` is supported by both Starlette <1.0 and 1.0+, so this is backwards-compatible.

## Testing

Tested with:
- Python 3.14.3
- FastAPI 0.135.1
- Starlette 1.0.0
- ytnoti 3.0.0

The `AsyncYouTubeNotifier.run()` server starts successfully and WebSub subscriptions complete without errors.